### PR TITLE
Add product strain/grow types and enhance account management

### DIFF
--- a/app/assets/stylesheets/components/_address_autocomplete.scss
+++ b/app/assets/stylesheets/components/_address_autocomplete.scss
@@ -1,0 +1,171 @@
+.address-autocomplete-wrapper {
+  position: relative;
+}
+
+.address-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background-color: rgb(33, 37, 41); // Dark background to match theme
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 1060; // Higher than navbar (1040) and flash messages (1050)
+  max-height: 300px;
+  overflow-y: auto;
+  margin-top: 4px;
+
+  // Show above input when near bottom of screen
+  &.position-above {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 4px;
+  }
+
+  // Custom scrollbar for dark theme
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 3px;
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.4);
+    }
+  }
+}
+
+.address-suggestion {
+  transition: background-color 0.2s ease;
+  
+  &:first-child {
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+  }
+  
+  &:last-child {
+    border-bottom: none;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+  
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+  }
+  
+  .bi-geo-alt {
+    color: rgba(255, 255, 255, 0.8); // More visible
+    font-size: 1rem; // Slightly larger
+    flex-shrink: 0;
+  }
+  
+  // Make subtext more readable
+  small {
+    color: rgba(255, 255, 255, 0.7) !important; // More visible than muted
+  }
+}
+
+// Address autocomplete specific styles - completely override any conflicting styles
+.address-autocomplete-wrapper {
+  position: relative;
+  
+  .search-input-wrapper {
+    position: relative;
+    display: block;
+  }
+  
+  // Form control - make sure it has proper height
+  .form-control {
+    height: 48px; // Standard Bootstrap form-control height
+    padding-right: 50px !important; // Make space for icon
+  }
+  
+  // Icon button positioning - calculate from Bootstrap form-control specs
+  .search-icon-btn {
+    position: absolute !important;
+    top: 0 !important;
+    right: 0 !important;
+    width: 48px !important;
+    height: 48px !important; // Same as form control height
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border: none !important;
+    background: transparent !important;
+    cursor: pointer !important;
+    z-index: 5 !important;
+    
+    i {
+      font-size: 16px !important;
+      color: rgba(255, 255, 255, 0.6) !important;
+      line-height: 1 !important;
+    }
+    
+    &:hover i {
+      color: rgba(255, 255, 255, 0.8) !important;
+    }
+    
+    &:focus {
+      outline: none !important;
+    }
+  }
+}
+
+// Loading state - show spinner in exact center of button area
+.address-autocomplete-wrapper.loading {
+  .search-icon-btn {
+    opacity: 0 !important;
+  }
+  
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 24px; // Center of 48px button: 48/2 = 24px
+    width: 16px;
+    height: 16px;
+    margin-top: -8px; // Half of spinner height for perfect centering
+    margin-right: -8px; // Half of spinner width for perfect centering
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top-color: rgba(255, 255, 255, 0.8);
+    animation: spin 1s linear infinite;
+    z-index: 10;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+// Mobile optimizations
+@media (max-width: 768px) {
+  .address-suggestions {
+    max-height: 250px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+  
+  .address-suggestion {
+    padding: 12px !important;
+    
+    .fw-medium {
+      font-size: 0.95rem;
+    }
+    
+    small {
+      font-size: 0.8rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -27,14 +27,13 @@
 
 .messages-container {
   background-color: #0d1117 !important;
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
   
   @media (max-width: 768px) {
     padding: 1rem !important;
     padding-bottom: 2rem !important;
-    
-    // Better scrolling on mobile
-    -webkit-overflow-scrolling: touch;
-    scroll-behavior: smooth;
   }
 }
 
@@ -137,7 +136,6 @@
 // Ensure chat takes full screen on mobile
 @media (max-width: 768px) {
   body.chat-page {
-    overflow: hidden;
     padding-bottom: 0 !important;
     
     .vh-100 {

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,19 +1,99 @@
+// Base dark form styling (no border, for search inputs etc)
 .gc-form {
   display: flex;
   flex-direction: column;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
 
-  background-color: transparent !important;
-  color: rgba(255, 255, 255, 0.5) !important;
-
-  ::placeholder {
-    color: rgba(255, 255, 255, 0.5);
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-webkit-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-moz-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &:-ms-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
   }
   
   &:focus {
-    background-color: transparent !important;
-    color: rgba(255, 255, 255, 0.5) !important;
-    box-shadow: none !important;
-    border-color: rgba(255, 255, 255, 0.3) !important;
+    background-color: rgba(0, 0, 0, 0.3) !important;
+    color: rgba(255, 255, 255, 1) !important;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25) !important;
+  }
+}
+
+// Apply gc-form styling to all form controls in search wrappers
+.search-input-wrapper .form-control,
+.address-autocomplete-wrapper .form-control {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-webkit-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-moz-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &:-ms-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &:focus {
+    background-color: rgba(0, 0, 0, 0.3) !important;
+    color: rgba(255, 255, 255, 1) !important;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25) !important;
+  }
+}
+
+// Style chat message input and ratings textarea
+.message-input-container .form-control,
+.rating-modal .form-control {
+  background-color: rgba(0, 0, 0, 0.2) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  border-color: rgba(255, 255, 255, 0.3) !important;
+  
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-webkit-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &::-moz-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &:-ms-input-placeholder {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  
+  &:focus {
+    background-color: rgba(0, 0, 0, 0.3) !important;
+    color: rgba(255, 255, 255, 1) !important;
+    border-color: rgba(255, 255, 255, 0.6) !important;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25) !important;
+  }
+}
+
+// Specific styling for account page forms that need visible borders
+.account-form-input.gc-form {
+  border: 1px solid rgba(255, 255, 255, 0.3) !important;
+  
+  &:focus {
+    border-color: rgba(255, 255, 255, 0.6) !important;
   }
 }
 

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -12,3 +12,4 @@
 @import "star_rating";
 @import "chat";
 @import "button";
+@import "address_autocomplete";

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,5 +10,62 @@ class PagesController < ApplicationController
 
   def account
     @user = current_user
+    @new_driver = User.new if @user.admin?
+  end
+
+  def update_password
+    @user = current_user
+    
+    if @user.update_with_password(password_params)
+      bypass_sign_in(@user)
+      redirect_to account_path, notice: 'Password updated successfully.'
+    else
+      redirect_to account_path, alert: @user.errors.full_messages.join(', ')
+    end
+  end
+
+  def update_username
+    @user = current_user
+    
+    if @user.update(username: params[:user][:username])
+      redirect_to account_path, notice: 'Username updated successfully.'
+    else
+      redirect_to account_path, alert: @user.errors.full_messages.join(', ')
+    end
+  end
+
+  def delete_account
+    @user = current_user
+    
+    if @user.valid_password?(params[:user][:current_password])
+      @user.destroy
+      redirect_to root_path, notice: 'Account deleted successfully.'
+    else
+      redirect_to account_path, alert: 'Incorrect password. Account not deleted.'
+    end
+  end
+
+  def create_driver
+    redirect_to account_path, alert: 'Access denied.' unless current_user.admin?
+    
+    @new_driver = User.new(driver_params)
+    @new_driver.role = :driver
+    
+    if @new_driver.save
+      redirect_to account_path, notice: "Driver #{@new_driver.username} created successfully."
+    else
+      @user = current_user
+      redirect_to account_path, alert: @new_driver.errors.full_messages.join(', ')
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+
+  def driver_params
+    params.require(:new_driver).permit(:username, :email, :password, :password_confirmation)
   end
 end

--- a/app/javascript/controllers/address_autocomplete_controller.js
+++ b/app/javascript/controllers/address_autocomplete_controller.js
@@ -1,0 +1,277 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "dropdown", "iconBtn", "icon"]
+  static values = { country: String }
+
+  connect() {
+    // Default to South Africa if no country specified
+    this.country = this.countryValue || "ZA"
+    this.timeout = null
+    // Initialize the icon state
+    this.updateIcon()
+  }
+
+  search() {
+    // Clear any existing timeout
+    clearTimeout(this.timeout)
+    
+    const query = this.inputTarget.value.trim()
+    
+    if (query.length < 3) {
+      this.hideDropdown()
+      return
+    }
+
+    // Debounce the search to avoid too many requests
+    this.timeout = setTimeout(() => {
+      this.performSearch(query)
+    }, 300)
+  }
+
+  async performSearch(query) {
+    try {
+      // Show loading state
+      this.element.classList.add('loading')
+      
+      // Using Nominatim (OpenStreetMap) free geocoding service
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&countrycodes=${this.country}&q=${encodeURIComponent(query)}`,
+        {
+          headers: {
+            'User-Agent': 'GoldCloud-App/1.0' // Required by Nominatim
+          }
+        }
+      )
+      
+      if (!response.ok) {
+        throw new Error('Geocoding service unavailable')
+      }
+      
+      const results = await response.json()
+      this.showSuggestions(results)
+      
+    } catch (error) {
+      console.error('Address search error:', error)
+      this.showError()
+    } finally {
+      // Remove loading state
+      this.element.classList.remove('loading')
+    }
+  }
+
+  showSuggestions(results) {
+    if (results.length === 0) {
+      this.hideDropdown()
+      return
+    }
+
+    // Clear existing suggestions
+    this.dropdownTarget.innerHTML = ''
+    
+    results.forEach(result => {
+      const suggestion = this.createSuggestionElement(result)
+      this.dropdownTarget.appendChild(suggestion)
+    })
+    
+    // Check if we should position above to avoid navbar
+    this.adjustPosition()
+    
+    this.dropdownTarget.classList.remove('d-none')
+  }
+
+  adjustPosition() {
+    // Check if dropdown would be hidden by bottom navbar
+    const inputRect = this.inputTarget.getBoundingClientRect()
+    const viewportHeight = window.innerHeight
+    const navbarHeight = 97 // Your app's navbar height
+    const availableSpace = viewportHeight - navbarHeight - inputRect.bottom
+    const dropdownHeight = 300 // max-height from CSS
+    
+    if (availableSpace < dropdownHeight && inputRect.top > dropdownHeight) {
+      // Not enough space below, but enough above - show above
+      this.dropdownTarget.classList.add('position-above')
+    } else {
+      // Show below as normal
+      this.dropdownTarget.classList.remove('position-above')
+    }
+  }
+
+  createSuggestionElement(result) {
+    const div = document.createElement('div')
+    div.className = 'address-suggestion p-3 border-bottom'
+    div.style.cursor = 'pointer'
+    
+    // Format the address nicely
+    const address = this.formatAddress(result)
+    
+    div.innerHTML = `
+      <div class="d-flex align-items-center">
+        <i class="bi bi-geo-alt me-2"></i>
+        <div>
+          <div class="fw-medium text-white">${address.main}</div>
+          ${address.detail ? `<small>${address.detail}</small>` : ''}
+        </div>
+      </div>
+    `
+    
+    div.addEventListener('click', () => {
+      this.selectAddress(result.display_name)
+    })
+    
+    div.addEventListener('mouseenter', () => {
+      div.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'
+    })
+    
+    div.addEventListener('mouseleave', () => {
+      div.style.backgroundColor = 'transparent'
+    })
+    
+    return div
+  }
+
+  formatAddress(result) {
+    const address = result.address || {}
+    
+    // Build main address line
+    const parts = []
+    
+    if (address.house_number) parts.push(address.house_number)
+    if (address.road) parts.push(address.road)
+    if (address.suburb) parts.push(address.suburb)
+    
+    const main = parts.join(' ') || result.display_name.split(',')[0]
+    
+    // Build detail line
+    const details = []
+    if (address.city) details.push(address.city)
+    if (address.state) details.push(address.state)
+    if (address.postcode) details.push(address.postcode)
+    
+    return {
+      main: main,
+      detail: details.join(', ')
+    }
+  }
+
+  selectAddress(address) {
+    this.inputTarget.value = address
+    this.hideDropdown()
+    this.updateIcon()
+    
+    // Trigger change event so other parts of the form know the value changed
+    this.inputTarget.dispatchEvent(new Event('change', { bubbles: true }))
+  }
+
+  showError() {
+    this.dropdownTarget.innerHTML = `
+      <div class="address-suggestion p-3">
+        <div class="d-flex align-items-center">
+          <i class="bi bi-exclamation-triangle me-2 text-warning"></i>
+          <div>
+            <div class="text-white-50">Unable to load address suggestions</div>
+            <small class="text-muted">Please type your full address manually</small>
+          </div>
+        </div>
+      </div>
+    `
+    this.dropdownTarget.classList.remove('d-none')
+    
+    // Hide error after 3 seconds
+    setTimeout(() => {
+      this.hideDropdown()
+    }, 3000)
+  }
+
+  hideDropdown() {
+    this.dropdownTarget.classList.add('d-none')
+  }
+
+  // Hide dropdown when clicking outside
+  clickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideDropdown()
+    }
+  }
+
+  // Handle keyboard navigation
+  keydown(event) {
+    const suggestions = this.dropdownTarget.querySelectorAll('.address-suggestion')
+    
+    if (suggestions.length === 0) return
+    
+    let activeIndex = Array.from(suggestions).findIndex(s => 
+      s.style.backgroundColor === 'rgba(255, 255, 255, 0.1)'
+    )
+    
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        activeIndex = activeIndex < suggestions.length - 1 ? activeIndex + 1 : 0
+        this.highlightSuggestion(suggestions, activeIndex)
+        break
+        
+      case 'ArrowUp':
+        event.preventDefault()
+        activeIndex = activeIndex > 0 ? activeIndex - 1 : suggestions.length - 1
+        this.highlightSuggestion(suggestions, activeIndex)
+        break
+        
+      case 'Enter':
+        event.preventDefault()
+        if (activeIndex >= 0) {
+          suggestions[activeIndex].click()
+        }
+        break
+        
+      case 'Escape':
+        this.hideDropdown()
+        break
+    }
+  }
+
+  highlightSuggestion(suggestions, activeIndex) {
+    suggestions.forEach((s, i) => {
+      s.style.backgroundColor = i === activeIndex ? 'rgba(255, 255, 255, 0.1)' : 'transparent'
+    })
+  }
+
+  // Clear the input when X is clicked
+  clear() {
+    this.inputTarget.value = ''
+    this.hideDropdown()
+    this.updateIcon()
+    this.inputTarget.focus()
+  }
+
+  // Handle icon click (search or clear)
+  handleIconClick() {
+    if (this.inputTarget.value.trim() !== '') {
+      this.clear()
+    }
+    // If it's search mode (empty input), do nothing
+  }
+
+  // Update icon based on input content
+  updateIcon() {
+    // Only update if we have icon targets
+    if (!this.hasIconTarget || !this.hasIconBtnTarget) return
+    
+    const hasContent = this.inputTarget.value.trim() !== ''
+    
+    if (hasContent) {
+      // Switch to clear mode
+      this.iconTarget.className = 'bi bi-x-lg'
+      this.iconBtnTarget.className = 'search-icon-btn clear-mode'
+    } else {
+      // Switch to search mode
+      this.iconTarget.className = 'bi bi-search'
+      this.iconBtnTarget.className = 'search-icon-btn search-mode'
+    }
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+    document.removeEventListener('click', this.clickOutside.bind(this))
+  }
+}

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,54 +23,70 @@ class Item < ApplicationRecord
     
     # Database-agnostic search method
     # Works with both SQLite (LIKE) and PostgreSQL (ILIKE)
-    itemable_types = ['Product', 'Package']
-    
-    # Determine if we're using PostgreSQL or SQLite
     like_operator = ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql' ? 'ILIKE' : 'LIKE'
     search_term = "%#{query}%"
   
-    conditions = itemable_types.map do |type|
-      if type == 'Product'
-        if like_operator == 'LIKE'
-          # SQLite: case insensitive using LOWER
-          [
-            "LOWER(products.name) LIKE LOWER(?)",
-            "LOWER(products.description) LIKE LOWER(?)", 
-            "LOWER(products.strain_type) LIKE LOWER(?)",
-            "LOWER(products.grow_type) LIKE LOWER(?)"
-          ].join(' OR ')
-        else
-          # PostgreSQL: use ILIKE for case insensitive
-          [
-            "products.name ILIKE ?",
-            "products.description ILIKE ?",
-            "products.strain_type ILIKE ?",
-            "products.grow_type ILIKE ?"
-          ].join(' OR ')
-        end
-      else
-        if like_operator == 'LIKE'
-          # SQLite: case insensitive using LOWER
-          [
-            "LOWER(packages.name) LIKE LOWER(?)",
-            "LOWER(packages.description) LIKE LOWER(?)"
-          ].join(' OR ')
-        else
-          # PostgreSQL: use ILIKE for case insensitive
-          [
-            "packages.name ILIKE ?",
-            "packages.description ILIKE ?"
-          ].join(' OR ')
-        end
-      end
-    end.join(' OR ')
+    # Search in products directly
+    product_conditions = if like_operator == 'LIKE'
+      # SQLite: case insensitive using LOWER
+      [
+        "LOWER(products.name) LIKE LOWER(?)",
+        "LOWER(products.description) LIKE LOWER(?)", 
+        "LOWER(products.strain_type) LIKE LOWER(?)",
+        "LOWER(products.grow_type) LIKE LOWER(?)"
+      ].join(' OR ')
+    else
+      # PostgreSQL: use ILIKE for case insensitive
+      [
+        "products.name ILIKE ?",
+        "products.description ILIKE ?",
+        "products.strain_type ILIKE ?",
+        "products.grow_type ILIKE ?"
+      ].join(' OR ')
+    end
+
+    # Search in packages directly
+    package_conditions = if like_operator == 'LIKE'
+      # SQLite: case insensitive using LOWER
+      [
+        "LOWER(packages.name) LIKE LOWER(?)",
+        "LOWER(packages.description) LIKE LOWER(?)"
+      ].join(' OR ')
+    else
+      # PostgreSQL: use ILIKE for case insensitive
+      [
+        "packages.name ILIKE ?",
+        "packages.description ILIKE ?"
+      ].join(' OR ')
+    end
+
+    # Search for packages that contain products with matching strain/grow types
+    package_product_conditions = if like_operator == 'LIKE'
+      [
+        "LOWER(package_products_search.strain_type) LIKE LOWER(?)",
+        "LOWER(package_products_search.grow_type) LIKE LOWER(?)"
+      ].join(' OR ')
+    else
+      [
+        "package_products_search.strain_type ILIKE ?",
+        "package_products_search.grow_type ILIKE ?"
+      ].join(' OR ')
+    end
+
+    # Combine all conditions
+    all_conditions = [
+      "(items.itemable_type = 'Product' AND (#{product_conditions}))",
+      "(items.itemable_type = 'Package' AND (#{package_conditions}))",
+      "(items.itemable_type = 'Package' AND items.itemable_id IN (SELECT DISTINCT packages.id FROM packages INNER JOIN package_products ON packages.id = package_products.package_id INNER JOIN products AS package_products_search ON package_products.product_id = package_products_search.id WHERE #{package_product_conditions}))"
+    ].join(' OR ')
   
     # Use explicit joins for better database compatibility
     joins("LEFT JOIN products ON items.itemable_type = 'Product' AND items.itemable_id = products.id")
       .joins("LEFT JOIN packages ON items.itemable_type = 'Package' AND items.itemable_id = packages.id")
-      .where(conditions, 
+      .where(all_conditions, 
         search_term, search_term, search_term, search_term,  # for products
-        search_term, search_term                              # for packages
+        search_term, search_term,                            # for packages
+        search_term, search_term                             # for package products
       )
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,6 @@
 class Product < ApplicationRecord
   STRAIN_TYPES = %w[indica sativa hybrid].freeze
-  GROW_TYPES = %w[indoor greenhouse].freeze
+  GROW_TYPES = %w[indoor outdoor greenhouse].freeze
 
   has_one :item, as: :itemable, dependent: :destroy
   has_many :package_products

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -12,6 +12,24 @@
             <p title="<%= item.itemable.name %>">
               <%= truncate(item.itemable.name, length: 20, omission: '...') %>
             </p>
+            <% if item.itemable_type == 'Product' && (item.itemable.strain_type.present? || item.itemable.grow_type.present?) %>
+              <div class="my-1 d-flex gap-1 flex-wrap">
+                <% if item.itemable.strain_type.present? %>
+                  <span class="badge <%= case item.itemable.strain_type
+                    when 'indica' then 'bg-warning text-dark'
+                    when 'sativa' then 'bg-success text-dark'
+                    when 'hybrid' then 'bg-info text-dark'
+                  end %>" style="font-size: 0.65rem;">
+                    <%= item.itemable.strain_type.capitalize %>
+                  </span>
+                <% end %>
+                <% if item.itemable.grow_type.present? %>
+                  <span class="badge bg-secondary" style="font-size: 0.65rem;">
+                    <%= item.itemable.grow_type.capitalize %>
+                  </span>
+                <% end %>
+              </div>
+            <% end %>
             <p id="item-price">
               R<%= item.itemable.price.round%><%= "/g" if item.itemable_type == 'Product' %>
             </p>

--- a/app/views/items/_product_info.html.erb
+++ b/app/views/items/_product_info.html.erb
@@ -1,0 +1,40 @@
+<% if item.itemable_type == "Product" && (item.itemable.strain_type.present? || item.itemable.grow_type.present?) %>
+  <div class="product-info-section mb-4">
+    <div class="row g-3">
+      <% if item.itemable.strain_type.present? %>
+        <div class="col-6">
+          <div class="info-card h-100 p-3 rounded" style="background-color: rgba(33, 37, 41, 0.8); border: 1px solid rgba(255, 255, 255, 0.2);">
+            <div class="d-flex align-items-center">
+              <i class="bi bi-flower1 text-success me-4" style="font-size: 1.6rem;"></i>
+              <div>
+                <p class="text-white-50 mb-0 small">Strain Type</p>
+                <p class="text-white mb-0 fw-semibold text-capitalize"><%= item.itemable.strain_type %></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+      
+      <% if item.itemable.grow_type.present? %>
+        <div class="col-6">
+          <div class="info-card h-100 p-3 rounded" style="background-color: rgba(33, 37, 41, 0.8); border: 1px solid rgba(255, 255, 255, 0.2);">
+            <div class="d-flex align-items-center">
+              <% case item.itemable.grow_type %>
+                <% when 'indoor' %>
+                  <i class="bi bi-house text-primary me-4" style="font-size: 1.6rem;"></i>
+                <% when 'outdoor' %>
+                  <i class="bi bi-sun text-warning me-4" style="font-size: 1.6rem;"></i>
+                <% when 'greenhouse' %>
+                  <i class="bi bi-building text-info me-4" style="font-size: 1.6rem;"></i>
+              <% end %>
+              <div>
+                <p class="text-white-50 mb-0 small">Grow Type</p>
+                <p class="text-white mb-0 fw-semibold text-capitalize"><%= item.itemable.grow_type %></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -12,7 +12,7 @@
   <%= form_with(url: search_items_path, method: :get, class: "gc-form", local: false) do |f| %>
     <div class="search-input-wrapper">
       <%= f.text_field :query,
-                        class: "form-control gc-form",
+                        class: "form-control",
                         placeholder: "Search by name, strain, or grow type...",
                         data: {
                           search_target: "input",

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -13,6 +13,8 @@
 
   <%= render 'description', item: @item %>
 
+  <%= render 'product_info', item: @item %>
+
   <% if @item.itemable_type == "Package" %>
     <%= render 'package_items', item: @item %>
   <% end %>

--- a/app/views/orders/checkout.html.erb
+++ b/app/views/orders/checkout.html.erb
@@ -28,7 +28,27 @@
   </div>
   <%= form_with(model: @order, url: confirm_order_order_path(@order), method: :patch, local: true) do |form| %>
     <div class="mb-3 gc-form">
-      <%= form.text_field :address, class: "form-control gc-form mb-2", placeholder: "Enter delivery address", required: true %>
+      <div class="address-autocomplete-wrapper" 
+           data-controller="address-autocomplete" 
+           data-address-autocomplete-country-value="ZA"
+           data-action="click@document->address-autocomplete#clickOutside">
+        <div class="search-input-wrapper">
+          <%= form.text_field :address, 
+              class: "form-control mb-2", 
+              placeholder: "Enter delivery address", 
+              required: true,
+              data: { 
+                address_autocomplete_target: "input",
+                action: "input->address-autocomplete#search keydown->address-autocomplete#keydown input->address-autocomplete#updateIcon"
+              } %>
+          <button type="button" class="search-icon-btn" data-address-autocomplete-target="iconBtn" data-action="click->address-autocomplete#handleIconClick">
+            <i class="bi bi-search" data-address-autocomplete-target="icon"></i>
+          </button>
+        </div>
+        <div class="address-suggestions d-none" 
+             data-address-autocomplete-target="dropdown">
+        </div>
+      </div>
       <%= form.submit "Place Order", class: "btn btn-lg btn-success" %>
     </div>
   <% end %>

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -1,3 +1,141 @@
 <div class="container mb-navbar mt-5">
-  <h1>Your account</h1>
+  <div class="d-flex align-items-center border-bottom pb-3 mb-4">
+    <h1 class="m-0">Your Account</h1>
+    <span class="badge bg-<%= @user.admin? ? 'danger' : @user.driver? ? 'warning' : 'primary' %> ms-3">
+      <%= @user.role.capitalize %>
+    </span>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-8">
+      <!-- Account Information -->
+      <div class="card mb-4" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+        <div class="card-header">
+          <h5 class="mb-0 text-white">Account Information</h5>
+        </div>
+        <div class="card-body">
+          <div class="row mb-3">
+            <div class="col-sm-3">
+              <strong class="text-white">Username:</strong>
+            </div>
+            <div class="col-sm-9">
+              <span class="text-light"><%= @user.username %></span>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-3">
+              <strong class="text-white">Email:</strong>
+            </div>
+            <div class="col-sm-9">
+              <span class="text-light"><%= @user.email %></span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Change Username -->
+      <div class="card mb-4" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+        <div class="card-header">
+          <h5 class="mb-0 text-white">Change Username</h5>
+        </div>
+        <div class="card-body">
+          <%= form_with(model: @user, url: update_username_path, method: :patch, local: true, class: "d-flex align-items-end gap-3") do |form| %>
+            <div class="flex-grow-1">
+              <%= form.text_field :username, class: "form-control gc-form account-form-input", placeholder: "New username", value: @user.username %>
+            </div>
+            <div>
+              <%= form.submit "Update Username", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- Change Password -->
+      <div class="card mb-4" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+        <div class="card-header">
+          <h5 class="mb-0 text-white">Change Password</h5>
+        </div>
+        <div class="card-body">
+          <%= form_with(model: @user, url: update_password_path, method: :patch, local: true) do |form| %>
+            <div class="mb-3">
+              <%= form.password_field :current_password, class: "form-control gc-form account-form-input", placeholder: "Current password", required: true %>
+            </div>
+            <div class="mb-3">
+              <%= form.password_field :password, class: "form-control gc-form account-form-input", placeholder: "New password", required: true %>
+            </div>
+            <div class="mb-3">
+              <%= form.password_field :password_confirmation, class: "form-control gc-form account-form-input", placeholder: "Confirm new password", required: true %>
+            </div>
+            <%= form.submit "Update Password", class: "btn btn-primary" %>
+          <% end %>
+        </div>
+      </div>
+
+      <% if @user.admin? %>
+        <!-- Admin: Create Driver -->
+        <div class="card mb-4" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+          <div class="card-header">
+            <h5 class="mb-0 text-white">Create New Driver</h5>
+          </div>
+          <div class="card-body">
+            <%= form_with(url: create_driver_path, method: :post, local: true) do |form| %>
+              <div class="mb-3">
+                <%= form.text_field "new_driver[username]", class: "form-control gc-form account-form-input", placeholder: "Driver username", required: true %>
+              </div>
+              <div class="mb-3">
+                <%= form.email_field "new_driver[email]", class: "form-control gc-form account-form-input", placeholder: "Driver email", required: true %>
+              </div>
+              <div class="mb-3">
+                <%= form.password_field "new_driver[password]", class: "form-control gc-form account-form-input", placeholder: "Driver password", required: true %>
+              </div>
+              <div class="mb-3">
+                <%= form.password_field "new_driver[password_confirmation]", class: "form-control gc-form account-form-input", placeholder: "Confirm driver password", required: true %>
+              </div>
+              <%= form.submit "Create Driver", class: "btn btn-success" %>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <!-- Customer: Delete Account -->
+        <div class="card mb-4" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+          <div class="card-header">
+            <h5 class="mb-0 text-danger">Danger Zone</h5>
+          </div>
+          <div class="card-body">
+            <p class="text-light mb-3">
+              <strong class="text-warning">Warning:</strong> This action cannot be undone. This will permanently delete your account and all associated data.
+            </p>
+            <%= form_with(model: @user, url: delete_account_path, method: :delete, local: true, data: { confirm: "Are you sure you want to delete your account? This action cannot be undone." }) do |form| %>
+              <div class="mb-3">
+                <%= form.password_field :current_password, class: "form-control gc-form account-form-input", placeholder: "Enter your password to confirm", required: true %>
+              </div>
+              <%= form.submit "Delete Account", class: "btn btn-danger" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="col-lg-4">
+      <!-- Quick Actions -->
+      <div class="card" style="background-color: rgba(33, 37, 41, 0.95); border: 1px solid rgba(255, 255, 255, 0.3);">
+        <div class="card-header">
+          <h5 class="mb-0 text-white">Quick Actions</h5>
+        </div>
+        <div class="card-body">
+          <div class="d-grid gap-2">
+            <%= link_to "View Orders", orders_path, class: "btn btn-outline-light" %>
+            <% if @user.admin? %>
+              <%= link_to "Manage Items", items_path, class: "btn btn-outline-light" %>
+              <%= link_to "View All Orders", orders_path, class: "btn btn-outline-light" %>
+            <% else %>
+              <%= link_to "Browse Products", items_path, class: "btn btn-outline-light" %>
+              <%= link_to "View Cart", cart_path, class: "btn btn-outline-light" %>
+            <% end %>
+            <%= link_to "Sign Out", destroy_user_session_path, method: :delete, class: "btn btn-outline-secondary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -9,6 +9,8 @@
     <%= f.input :name, required: false %>
     <%= f.input :description %>
     <%= f.input :price, required: false, label: "Price / gram" %>
+    <%= f.input :strain_type, collection: Product::STRAIN_TYPES, prompt: 'Select strain type', include_blank: false %>
+    <%= f.input :grow_type, collection: Product::GROW_TYPES, prompt: 'Select grow type', include_blank: false %>
     <div class="mb-2">
       <% if @product.photos.attached? %>
         <% @product.photos.each do |photo| %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -4,6 +4,8 @@
     <%= f.input :name, required: false %>
     <%= f.input :description %>
     <%= f.input :price, required: false, label: 'Price per gram', placeholder: "R" %>
+    <%= f.input :strain_type, collection: Product::STRAIN_TYPES, prompt: 'Select strain type', include_blank: false %>
+    <%= f.input :grow_type, collection: Product::GROW_TYPES, prompt: 'Select grow type', include_blank: false %>
     <%= f.input :photos, as: :file, input_html: { multiple: true } %>
     <%= f.submit "Add Product", class: "btn btn-success mt-3" %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,14 @@ Rails.application.routes.draw do
   get 'cart', to: 'orders#cart'
   get 'checkout', to: 'orders#checkout'
   get 'account', to: 'pages#account', as: 'account'
+  
+  # User account management
+  patch 'account/update_password', to: 'pages#update_password', as: 'update_password'
+  patch 'account/update_username', to: 'pages#update_username', as: 'update_username'
+  delete 'account/delete', to: 'pages#delete_account', as: 'delete_account'
+  
+  # Admin driver management
+  post 'account/create_driver', to: 'pages#create_driver', as: 'create_driver'
 
   resources :orders do
     member do

--- a/db/migrate/20250820044040_remove_address_from_users.rb
+++ b/db/migrate/20250820044040_remove_address_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAddressFromUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_19_051838) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_20_044040) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -76,7 +78,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_19_051838) do
     t.datetime "updated_at", null: false
     t.string "itemable_type"
     t.bigint "itemable_id"
-    t.json "item_snapshot"
+    t.jsonb "item_snapshot"
+    t.index ["item_snapshot"], name: "index_order_items_on_item_snapshot", using: :gin
     t.index ["itemable_type", "itemable_id"], name: "index_order_items_on_itemable"
     t.index ["order_id"], name: "index_order_items_on_order_id"
     t.index ["package_id"], name: "index_order_items_on_package_id"
@@ -147,7 +150,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_19_051838) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role", default: 2, null: false
-    t.string "address"
     t.string "username", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,6 @@ Package.destroy_all
 # 1. king user (admin)
 admin = User.create!(
   username: "The Duke",
-  address: "admin@goldcloud.com",
   email: "test@test.com",
   password: "password",
   password_confirmation: "password",
@@ -23,7 +22,6 @@ admin = User.create!(
 # 2. create some customers
 stricko = User.create!(
   username: "Stricko",
-  address: "456 False Road, Faketown, 5678",
   email: "fake@fake.com",
   password: "password",
   password_confirmation: "password",
@@ -42,7 +40,6 @@ end
 # 3. Create some drivers
 driver1 = User.create!(
   username: "Driver 1",
-  address: "99 Madeup Corner, Faketown, 3378",
   email: "fake@driver.com",
   password: "password",
   password_confirmation: "password",
@@ -69,11 +66,16 @@ description_template = "This strain is a hybrid made from a genetic cross betwee
                         or outdoors in mild climates. The average price typically ranges from R120-R180 per gram."
 
 # Seed 20 products
+strain_types = ['indica', 'sativa', 'hybrid']
+grow_types = ['indoor', 'outdoor', 'greenhouse']
+
 product_names.each do |product_name|
   Product.create!(
     name: product_name,
     description: description_template,
     price: rand(10..20) * 10,
+    strain_type: strain_types.sample,
+    grow_type: grow_types.sample,
     available: true
   )
 end


### PR DESCRIPTION
Features:
- Add strain_type (indica/sativa/hybrid) and grow_type (indoor/outdoor/greenhouse) to products
- Update product forms and views to display strain and grow type information
- Enhanced search to include strain and grow types for products and packages
- Comprehensive account management system for users
- Role-based account features (customers: change password/username/delete account, admin: create drivers)
- Address autocomplete for checkout using Nominatim API
- Fix form accessibility with proper white text and placeholders
- Fix chat scrolling issues
- UI consistency improvements across all form inputs

🤖 Generated with [Claude Code](https://claude.ai/code)